### PR TITLE
`SecureString` to plain text conversion using `NetWorkCredential` instead of marshalling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ testResults.xml
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+### Custom entries ###
+output/
+tools/Modules
+test.settings.json
+tests/integration/.vagrant
+tests/integration/cert_setup

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "PowerShell launch",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "pwsh",
+      "args": [
+        "-NoExit",
+        "-NoProfile",
+        "-Command",
+        "Import-Module ./output/SteamPS"
+      ],
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "externalTerminal",
+      "windows": {}
+    },
+    {
+      "name": "PowerShell Launch Current File",
+      "type": "PowerShell",
+      "request": "launch",
+      "script": "${file}",
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,49 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "pwsh",
+            "type": "shell",
+            "args": [
+                "-File",
+                "${workspaceFolder}/build.ps1"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "update docs",
+            "command": "pwsh",
+            "type": "shell",
+            "args": [
+                "-Command",
+                "Import-Module ${workspaceFolder}/output/SteamPS; Import-Module ${workspaceFolder}/tools/Modules/platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
+            ],
+            "problemMatcher": [],
+            "dependsOn": [
+                "build"
+            ]
+        },
+        {
+            "label": "test",
+            "command": "pwsh",
+            "type": "shell",
+            "args": [
+                "-File",
+                "${workspaceFolder}/build.ps1",
+                "-Task",
+                "Test"
+            ],
+            "problemMatcher": [],
+            "dependsOn": [
+                "build"
+            ]
+        }
+    ]
+}

--- a/SteamPS/Private/API/Get-SteamAPIKey.ps1
+++ b/SteamPS/Private/API/Get-SteamAPIKey.ps1
@@ -29,7 +29,7 @@
             $Exception = [Exception]::new("Steam Web API configuration file not found in '$env:AppData\SteamPS\SteamPSKey.json'. Run Connect-SteamAPI to configure an API key.")
             $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
                 $Exception,
-                "SteamAPIKeyNotFound",
+                'SteamAPIKeyNotFound',
                 [System.Management.Automation.ErrorCategory]::ObjectNotFound,
                 $SteamPSKey # usually the object that triggered the error, if possible
             )
@@ -38,15 +38,12 @@
             try {
                 $Config = Get-Content "$env:AppData\SteamPS\SteamPSKey.json"
                 $APIKeySecString = $Config | ConvertTo-SecureString
-                $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($APIKeySecString)
-                $APIKey = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
-
-                Write-Output -InputObject $APIKey
+                [System.Net.NetworkCredential]::new('', $APIKeySecString).Password
             } catch {
                 $Exception = [Exception]::new("Could not decrypt API key from configuration file not found in '$env:AppData\SteamPS\SteamPSKey.json'. Run Connect-SteamAPI to configure an API key.")
                 $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
                     $Exception,
-                    "InvalidAPIKey",
+                    'InvalidAPIKey',
                     [System.Management.Automation.ErrorCategory]::ParserError,
                     $APIKey # usually the object that triggered the error, if possible
                 )

--- a/SteamPS/Private/Server/Add-EnvPath.ps1
+++ b/SteamPS/Private/Server/Add-EnvPath.ps1
@@ -6,7 +6,7 @@
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Path,
 
         [ValidateSet('Machine', 'User', 'Session')]
@@ -22,7 +22,9 @@
             }
             $containerType = $containerMapping[$Container]
 
-            $persistedPaths = [Environment]::GetEnvironmentVariable('Path', $containerType) -split ';'
+            $persistedPaths = [Environment]::GetEnvironmentVariable('Path', $containerType).Split([System.IO.Path]::PathSeparator).Trim() |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
             if ($persistedPaths -notcontains $Path) {
                 $persistedPaths = $persistedPaths + $Path | Where-Object -FilterScript { $_ }
                 [Environment]::SetEnvironmentVariable('Path', $persistedPaths -join ';', $containerType)

--- a/SteamPS/Private/Server/Get-SteamPath.ps1
+++ b/SteamPS/Private/Server/Get-SteamPath.ps1
@@ -4,7 +4,9 @@
     )
 
     process {
-        $SteamCMDPath = $env:Path.Split(';') | Where-Object -FilterScript { $_ -like "*SteamCMD*" }
+        $SteamCMDPath = $env:Path.Split([System.IO.Path]::PathSeparator) |
+            Where-Object -FilterScript { $_ -like '*SteamCMD*' }
+
         if ($null -ne $SteamCMDPath) {
             [PSCustomObject]@{
                 'Path'       = $SteamCMDPath


### PR DESCRIPTION
# PR Summary

- [.gitignore](https://github.com/hjorslev/SteamPSCI/compare/master...santisq:SteamPSCI:master#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947)

Adding `tools/Modules` and `output` folder to `.gitignore`, otherwise the modules needed for CI/CD and the released module would get pushed to repository.

- [.vscode/launch.json](https://github.com/hjorslev/SteamPSCI/compare/master...santisq:SteamPSCI:master#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945)

Added `launch` file for easier debugging, i.e.: <kbd>Ctrl+Shift+Enter</kbd> opens a new `pwsh` with the module already loaded.

- [.vscode/tasks.json](https://github.com/hjorslev/SteamPSCI/compare/master...santisq:SteamPSCI:master#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745a)

Added `tasks` file, easier building, i.e.: <kbd>Ctrl+Shift+B</kbd> runs `build.ps1` and <kbd>F1</kbd> -> `Run Test Task` runs `build.ps1 -Task Test`.

- [SteamPS/Private/API/Get-SteamAPIKey.ps1](https://github.com/hjorslev/SteamPSCI/compare/master...santisq:SteamPSCI:master#diff-c7ac89838f29e692e782f0934638a81e49e042a8d0949587a03811c924aefe1c)

Using [`NetworkCredential`](https://learn.microsoft.com/en-us/dotnet/api/system.net.networkcredential?view=net-8.0) to decrypt the secure string instead of marshalling. This method properly handles the unmanaged memory, makes it simpler and correctly frees the unmanaged memory.

Otherwise, if marshalling:

1. `PtrToStringAuto` should be `PtrToStringBSTR` instead to avoid encoding issues.
2. There should be a `finally` block in the function that calls `[System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)` to free the unmanaged memory, otherwise the plain text password lives in unmanaged memory while the `pwsh` process is alive.

Both points above are correctly managed by `NetworkCredential`.

- [SteamPS/Private/Server/Add-EnvPath.ps1](https://github.com/hjorslev/SteamPSCI/compare/master...santisq:SteamPSCI:master#diff-54798a65d590e3c1f7434f8d3d31e872b6a35dc8f867d7e137facb5854d8e50c)

Using `[System.IO.Path]::PathSeparator` instead of `;` to split the path in case you want to make this module compatible with Linux in the future (its separator is `:`). `Trim()` to remove any extra trailing or leading whitespace from each token and then filtering any token that could be purely white space, i.e.:

```powershell
PS /> 'foo;; bar; baz ;;'.Split([System.IO.Path]::PathSeparator).Trim() -ne '' -join ';'
foo;bar;baz
```

- [SteamPS/Private/Server/Get-SteamPath.ps1](https://github.com/hjorslev/SteamPSCI/compare/master...santisq:SteamPSCI:master#diff-ba7a11219ac92b55008a3f51ce0c73c09ae61195c0c70008f3ae7dfca06afbac)

Same change to split using `[System.IO.Path]::PathSeparator`.

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

<!-- List any and all changes here, in bullet point form. -->

## Checklist

- [X] Pull Request has a meaningful title.
- [X] Summarised changes.
- [X] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.